### PR TITLE
Add missing Unknown feature type to orcaslicer.js

### DIFF
--- a/src/SlicerSpecific/orcaslicer.js
+++ b/src/SlicerSpecific/orcaslicer.js
@@ -67,7 +67,12 @@ export default class OrcaSlicer extends SlicerBase {
             color: new Color4(0.7, 0.89, 0.67, 1),
             perimeter: false,
             support: false
-         }
+         },
+         'Unknown': {
+            color: new Color4(0.5, 0.5, 0.5, 1),
+            perimeter: false ,
+            support : false
+         },
       };
    }
 


### PR DESCRIPTION
This should close #12 and resolve https://github.com/mainsail-crew/mainsail/issues/1752

This is beacuse some feature were missing and it was trying to read the `Unknown` feature which resolved in undefined.

`Skirt` and `Internal Bridge` are 2 feature missing that i saw but I don't know which color assign to them, I can also add them if you provide where to take such colors